### PR TITLE
Adding classes for type roles of two parameters combined

### DIFF
--- a/coercion-extras.cabal
+++ b/coercion-extras.cabal
@@ -18,7 +18,8 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Data.Type.Role.Nominal,
                        Data.Type.Role.Representational,
-                       Data.Type.Role.Phantom
+                       Data.Type.Role.Phantom,
+                       Data.Type.Role.Bi
   build-depends:       base >= 4.12 && == 4.*
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Data/Type/Role/Bi.hs
+++ b/src/Data/Type/Role/Bi.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
+
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+
+module Data.Type.Role.Bi(
+  Phantom2, Representational2, Nominal2, TypeRoles2
+) where
+
+import Data.Kind (Constraint)
+
+import Data.Type.Role.Phantom
+import Data.Type.Role.Representational
+import Data.Type.Role.Nominal
+
+-- | A constraint witnessing that the next two arguments of the type constructor
+-- of the @f@ type have the phantom type role.
+-- 
+-- This class is equivalent to
+-- 
+-- > TypeRoles2 Phantom Phantom f
+-- 
+-- but doesn't require @ConstraintKinds@ extension and
+-- provides convenient shorthand.
+class (Phantom f, forall a. Phantom (f a))
+  => Phantom2 (f :: j -> k -> l)
+instance (Phantom f, forall a. Phantom (f a))
+  => Phantom2 (f :: j -> k -> l)
+
+-- | A constraint witnessing that the next two arguments of the type constructor
+-- of the @f@ type have the representational type role.
+-- 
+-- This class is equivalent to
+-- 
+-- > TypeRoles2 Representational Representational f
+-- 
+-- but doesn't require @ConstraintKinds@ extension and
+-- provides convenient shorthand.
+class (Representational f, forall a. Representational (f a))
+  => Representational2 (f :: j -> k -> l)
+instance (Representational f, forall a. Representational (f a))
+  => Representational2 (f :: j -> k -> l)
+
+-- | A constraint witnessing that the next two arguments of the type constructor
+-- of the @f@ type have the nominal type role.
+-- 
+-- This class is provided only for completeness, everything is automatically an
+-- instance of this class.
+-- 
+-- This class is equivalent to
+-- 
+-- > TypeRoles2 Nominal Nominal f
+class Nominal2 (f :: j -> k -> l)
+instance Nominal2 (f :: j -> k -> l)
+
+-- | A constraint witnessing the next two arguments of the type constructor
+-- of the type @f@ is @r1@ and @r2@ respectively.
+--
+-- As 'Nominal' class is provided only for completeness, it may be useful to
+-- notice that roles containing @Nominal@ do not need this class.
+--
+-- > TypeRoles2 Nominal r       f -- Equivalent to (forall a. r (f a))
+-- > TypeRoles2 r       Nominal f -- Equivalent to (r f)
+class (r1 f, forall a. r2 (f a))
+  => TypeRoles2 (r1 :: (j -> k -> l) -> Constraint)
+                (r2 :: (k -> l) -> Constraint)
+                (f :: j -> k -> l)
+instance (r1 f, forall a. r2 (f a)) => TypeRoles2 r1 r2 f

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,13 +1,21 @@
 {-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GADTs #-}
 module Main where
 
 import Data.Type.Role.Nominal
 import Data.Type.Role.Representational
 import Data.Type.Role.Phantom
 
+import Data.Type.Role.Bi
+
 import Data.Map (Map)
 import Data.Proxy
 import Data.Set (Set)
+
+data Witness c f where
+  Witness :: c f => Witness c f
 
 testMaybe :: (Nominality Maybe, Representation Maybe, NonPhantomicity Maybe)
 testMaybe = (Nominality, Representation, NonPhantomicity)
@@ -18,11 +26,22 @@ testEithera = (Nominality, Representation, NonPhantomicity)
 testEither :: (Nominality Either, Representation Either, NonPhantomicity Either)
 testEither = (Nominality, Representation, NonPhantomicity)
 
+testEitherBi :: (Witness Nominal2 Either,
+                 Witness Representational2 Either,
+                 Witness (TypeRoles2 Representational Representational) Either,
+                 Witness (TypeRoles2 NonPhantom NonPhantom) Either)
+testEitherBi = (Witness, Witness, Witness, Witness)
+
 testMapk :: (Nominality (Map k), Representation (Map k), NonPhantomicity (Map k))
 testMapk = (Nominality, Representation, NonPhantomicity)
 
 testMap :: (Nominality Map, NonRepresentation Map, NonPhantomicity Map)
 testMap = (Nominality, NonRepresentation, NonPhantomicity)
+
+testMapBi :: (Witness Nominal2 Map,
+              Witness (TypeRoles2 NonRepresentational Representational) Map,
+              Witness (TypeRoles2 NonPhantom NonPhantom) Map)
+testMapBi = (Witness, Witness, Witness)
 
 testSet :: (Nominality Set, NonRepresentation Set, NonPhantomicity Set)
 testSet = (Nominality, NonRepresentation, NonPhantomicity)


### PR DESCRIPTION
Hi, I have a request for a feature.

When I want to represent the constraint a type takes 2 parameters of
`representaional` role, like `Either` or `(->)`, I must write one of:

* `(forall a a' b b'. (Coercible a a', Coercible b b') => Coercible (f a b) (f a' b'))`　without this library
* `(Representational f, forall a. Representational (f a)`　with this library

This PR adds `Representational2 f` for the shorthand of them, and other classes of similar purposes.

I'd be glad if you would add it to the library.
